### PR TITLE
Add map bounds check for laser intensity access

### DIFF
--- a/nav2_amcl/src/sensors/laser/likelihood_field_model.cpp
+++ b/nav2_amcl/src/sensors/laser/likelihood_field_model.cpp
@@ -115,14 +115,16 @@ LikelihoodFieldModel::sensorFunction(LaserData * data, pf_sample_set_t * set)
       pz += self->z_rand_ * z_rand_mult;
 
       if (self->use_intensity_ && data->intensities) {
-        double diff = fabs(data->intensities[i] -
-          self->map_->cells[MAP_INDEX(self->map_, mi, mj)].intensity);
-        double factor = diff <= self->intensity_threshold_ ?
-          (1.0 + self->intensity_weight_) : (1.0 - self->intensity_weight_);
-        if (factor < 0.0) {
-          factor = 0.0;
+        if (MAP_VALID(self->map_, mi, mj)) {
+          double diff = fabs(data->intensities[i] -
+            self->map_->cells[MAP_INDEX(self->map_, mi, mj)].intensity);
+          double factor = diff <= self->intensity_threshold_ ?
+            (1.0 + self->intensity_weight_) : (1.0 - self->intensity_weight_);
+          if (factor < 0.0) {
+            factor = 0.0;
+          }
+          pz *= factor;
         }
-        pz *= factor;
       }
 
       // TODO(?): outlier rejection for short readings

--- a/nav2_amcl/src/sensors/laser/likelihood_field_model_prob.cpp
+++ b/nav2_amcl/src/sensors/laser/likelihood_field_model_prob.cpp
@@ -175,14 +175,16 @@ LikelihoodFieldModelProb::sensorFunction(LaserData * data, pf_sample_set_t * set
       pz += self->z_rand_ * z_rand_mult;
 
       if (self->use_intensity_ && data->intensities) {
-        double diff = fabs(data->intensities[i] -
-          self->map_->cells[MAP_INDEX(self->map_, mi, mj)].intensity);
-        double factor = diff <= self->intensity_threshold_ ?
-          (1.0 + self->intensity_weight_) : (1.0 - self->intensity_weight_);
-        if (factor < 0.0) {
-          factor = 0.0;
+        if (MAP_VALID(self->map_, mi, mj)) {
+          double diff = fabs(data->intensities[i] -
+            self->map_->cells[MAP_INDEX(self->map_, mi, mj)].intensity);
+          double factor = diff <= self->intensity_threshold_ ?
+            (1.0 + self->intensity_weight_) : (1.0 - self->intensity_weight_);
+          if (factor < 0.0) {
+            factor = 0.0;
+          }
+          pz *= factor;
         }
-        pz *= factor;
       }
 
       assert(pz <= 1.0);


### PR DESCRIPTION
## Summary
- Validate map indices before reading cell intensity in likelihood field models

## Testing
- `sudo apt-get update` *(fails: repository not signed)*
- `colcon build --packages-select nav2_amcl` *(fails: command not found)*
- `ros2 run nav2_amcl amcl --ros-args -p use_intensity:=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0473d79a4832aa211827cf260350a